### PR TITLE
Feature/OP-890: Update due_date with extension date (new_due_date)

### DIFF
--- a/app/request/utils.py
+++ b/app/request/utils.py
@@ -72,7 +72,8 @@ def create_request(title,
     :param title: request title
     :param description: detailed description of the request
     :param agency: agency_ein selected for the request
-    :param date_created: date the request was made
+    :param first_name: first name of the requester
+    :param last_name: last name of the requester
     :param submission: request submission method
     :param agency_date_submitted: submission date chosen by agency_ein
     :param email: requester's email address
@@ -171,7 +172,8 @@ def create_request(title,
     request_metadata = {
         'title': request.title,
         'description': request.description,
-        'current_status': request.current_status
+        'current_status': request.current_status,
+        'due_date': request.due_date.isoformat()
     }
     event = Events(user_id=user.guid,
                    auth_user_type=user.auth_user_type,

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -24,7 +24,7 @@ from app.constants.response_privacy import (
     PRIVATE
 )
 from app.lib.date_utils import generate_new_due_date
-from app.lib.db_utils import create_object
+from app.lib.db_utils import create_object, update_object
 from app.lib.email_utils import send_email, get_agencies_emails
 from app.lib.file_utils import get_mime_type
 from app.models import (
@@ -128,6 +128,10 @@ def edit_note():
 
 def add_extension(request_id, length, reason, custom_due_date, email_content):
     new_due_date = _get_new_due_date(request_id, length, custom_due_date)
+    update_object(
+        {'due_date': new_due_date},
+        Requests,
+        request_id)
     extension = Extensions(reason=reason, date=new_due_date)
     create_object(obj=extension)
     extension_metadata = {'reason': reason,


### PR DESCRIPTION
due_date column now properly updates in the Requests table when an extension is added to a request.
due_date is now part of the request metadata for the new_response_value in the Events table when creating a new request.