### PR TITLE
Bugfix/OP-914: Disable horizontal resize on textareas

### DIFF
--- a/app/request/views.py
+++ b/app/request/views.py
@@ -160,6 +160,8 @@ def view(request_id):
         request_user_type=user_type_request.REQUESTER).first().user
     agency_users = UserRequests.query.filter_by(request_id=request_id,
                                                 request_user_type=user_type_request.AGENCY).all()
+    edit_requester_form = EditRequesterForm(
+        state=requester.mailing_address['state'] if requester.mailing_address is not None else None)
 
     edit_requester_form = EditRequesterForm(state=requester.mailing_address['state']
                                             if requester.mailing_address is not None

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -59,7 +59,8 @@
 	display:block;
 	-moz-box-sizing:content-box;
 	-webkit-box-sizing:content-box;
-	box-sizing:content-box
+	box-sizing:content-box;
+	resize: vertical;
 }
 
 .wrapper input[type=text],.wrapper select[type=text],.wrapper textarea[type=text]

--- a/app/static/styles/request_info.css
+++ b/app/static/styles/request_info.css
@@ -58,20 +58,26 @@ h3.control-widget {
 }
 
 /* sets width and font size of request title text input (called in xeditable js) */
-#request-title.request-editable {
-    width: 280px;
+#request-title {
+    width: 480px;
     font-size: 21px;
     max-height: 10rem;
+    resize: none;
+}
+
+/* sets padding on xeditable request title textarea */
+.request-title-text .editable-container {
+    padding-top: 10px;
 }
 
 /* sets width and font size of agency description text area input (called in xeditable js) */
-#agency-descr.request-editable {
+#agency-descr {
     width: 480px;
     font-size: 21px;
-    max-height: 20rem;
+    max-height: 17rem;
 }
 
-/* edits agency description xeditable text area input */
+/* sets padding on xeditable agency description textarea */
 .agency-desc-text .editable-container {
     padding-top: 10px;
 }

--- a/app/templates/request/_view_request_info.html
+++ b/app/templates/request/_view_request_info.html
@@ -5,12 +5,8 @@
             <br>
             <div class="row">
                 <div class="request-label lead col-sm-1">Title:</div>
-                <div class="request-title-text lead col-sm-8">
-                    <!-- editable area for request title -->
-                    <a href="#" class="xedit" id="title">{{ request.title }}</a>
-                </div>
                 <!-- privacy options for request title -->
-                <div class="btn-group" data-toggle="buttons">
+                <div class="btn-group col-sm-push-8" data-toggle="buttons">
                     {% if privacy['title'] %}
                         <label class="title-privacy-btn btn btn-default" data-active-class="primary">
                             <input type="radio" value="false">Public
@@ -26,6 +22,10 @@
                             <input type="radio" value="true">Private
                         </label>
                     {% endif %}
+                </div>
+                <div class="request-title-text lead">
+                    <!-- editable area for request title -->
+                    <a href="#" class="xedit" id="title">{{ request.title }}</a>
                 </div>
             </div>
             <br>

--- a/app/templates/request/_view_request_info_x-editable.html
+++ b/app/templates/request/_view_request_info_x-editable.html
@@ -19,7 +19,7 @@
             ajaxOptions: {
                 type: 'put'
             },
-            tpl: '<textarea id="request-title" class="request-editable" maxlength="90" data-parsley-required data-parsley-maxlength="90" rows="3"></textarea>',
+            tpl: '<textarea id="request-title" class="request-editable" maxlength="90" data-parsley-required data-parsley-maxlength="90" rows="3"></textarea>'
         });
 
         $('#agency_description').editable({


### PR DESCRIPTION
Disabled horizontal resize on textareas.
Disabled resizing on editing request textarea.
Set max resizing height on editing agency description because its parent div has a max height.