### PR TITLE
Feature/OP-913: Render Specific Email Template for File Responses Based on Privacy

### DIFF
--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -782,12 +782,12 @@ def get_file_links(response):
     path = '/response/' + str(response.id)
     requester_link = None
     if resp.privacy != PRIVATE:
-        if resp.request.requester is user_type_auth.ANONYMOUS_USER:
+        if resp.request.requester.is_anonymous_requester:
             resptoken = ResponseTokens(response.id)
             create_object(resptoken)
             params = urllib.parse.urlencode({'token': resptoken.token})
             requester_url = urljoin(flask_request.url_root, path)# link with token
-            requester_link = requester_url % params
+            requester_link = requester_url + "?%s" % params
         else:
             requester_link = urljoin(flask_request.url_root, path)
     agency_link = urljoin(flask_request.url_root, path)

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -784,6 +784,7 @@ def get_file_links(response, agency_file_links, requester_file_links):
     resp = Responses.query.filter_by(id=response.id).one()
     path = '/response/' + str(response.id)
 
+    agency_link = urljoin(flask_request.url_root, path)
     if resp.privacy != PRIVATE:
         if resp.request.requester.is_anonymous_requester:
             resptoken = ResponseTokens(response.id)
@@ -794,10 +795,9 @@ def get_file_links(response, agency_file_links, requester_file_links):
         else:
             requester_link = urljoin(flask_request.url_root, path)
         requester_file_links[resp.name] = requester_link
-
-    agency_link = urljoin(flask_request.url_root, path)
-    agency_file_links[resp.name] = agency_link
-
+        agency_file_links['release'][resp.name] = agency_link
+    else:
+        agency_file_links['private'][resp.name] = agency_link
     return agency_file_links, requester_file_links
 
 

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -53,7 +53,8 @@ from app.models import (
     Responses,
     Reasons,
     Determinations,
-    Emails
+    Emails,
+    ResponseTokens
 )
 
 
@@ -87,6 +88,10 @@ def add_file(request_id, filename, title, privacy):
         hash_,
     )
     create_object(response)
+
+    resptok = ResponseTokens(response.id)
+    create_object(resptok)
+
     _create_response_event(response, event_type.FILE_ADDED)
 
 
@@ -396,6 +401,17 @@ def process_email_template_request(request_id, data):
 
 
 def _acknowledgment_email_handler(request_id, data, page, agency_name, email_template):
+    """
+    Process email template for an acknowledgement.
+
+    :param request_id: FOIL request ID
+    :param data: data from frontend AJAX call
+    :param page: string url link of the request
+    :param agency_name: string name of the agency of the request
+    :param email_template: raw HTML email template of a response
+
+    :return: the HTML of the rendered template of an acknowledgement
+    """
     acknowledgment = data.get('acknowledgment')
 
     if acknowledgment is not None:

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -503,6 +503,8 @@ def _file_email_handler(request_id, data, page, agency_name, email_template):
         files = []
         default_content = True
         content = None
+        if eval_request_bool(data['is_private']):
+            email_template = 'email_templates/email_private_file_upload.html'
     # iterate through files dictionary to create and append links of files with privacy option of not private
     for file_ in files:
         if file_['privacy'] != PRIVATE:

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -339,35 +339,6 @@ def process_upload_data(form):
     return files
 
 
-def process_privacy_options(files):
-    """
-    Create a dictionary, files_privacy_options, containing lists of 'release' and 'private', with values of filenames.
-    Two empty lists: private_files and release_files are first created. Iterate through files dictionary to determine
-    the privacy options of file(s) and append to appropriate list. Create files_privacy_option dictionary with keys:
-    release, which holds release_files, and private, which holds private_files.
-
-    :param files: list of filenames
-
-    :return: Dictionary with 'release' and 'private' lists.
-    """
-    private_files = []
-    release_files = []
-    for filename in files:
-        if files[filename]['privacy'] == 'private':
-            private_files.append(filename)
-        else:
-            release_files.append(filename)
-
-    files_privacy_options = dict()
-
-    if release_files:
-        files_privacy_options['release'] = release_files
-
-    if private_files:
-        files_privacy_options['private'] = private_files
-    return files_privacy_options
-
-
 def process_email_template_request(request_id, data):
     """
     Process the email template for responses. Determine the type of response from passed in data and follows
@@ -524,7 +495,7 @@ def _file_email_handler(request_id, data, page, agency_name, email_template):
             email_template = 'email_templates/email_private_file_upload.html'
     # iterate through files dictionary to create and append links of files with privacy option of not private
     for file_ in files:
-        if file_['privacy'] != PRIVATE or eval_request_bool(data['is_private']) is True:
+        if file_['privacy'] != PRIVATE or eval_request_bool(data['is_private']):
             filename = file_['filename']
             files_links[filename] = "http://127.0.0.1:5000/request/view/{}".format(filename)
     return jsonify({"template": render_template(email_template,

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -507,9 +507,8 @@ def _file_email_handler(request_id, data, page, agency_name, email_template):
             email_template = 'email_templates/email_private_file_upload.html'
     # iterate through files dictionary to create and append links of files with privacy option of not private
     for file_ in files:
-        if file_['privacy'] != PRIVATE:
-            filename = file_['filename']
-            files_links[filename] = "http://127.0.0.1:5000/request/view/{}".format(filename)
+        filename = file_['filename']
+        files_links[filename] = "http://127.0.0.1:5000/request/view/{}".format(filename)
     return jsonify({"template": render_template(email_template,
                                                 default_content=default_content,
                                                 content=content,

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -100,6 +100,8 @@ def response_file(request_id):
     current_request = Requests.query.filter_by(id=request_id).first()
     files = process_upload_data(flask_request.form)
     agency_file_links = dict()
+    agency_file_links['private'] = dict()
+    agency_file_links['release'] = dict()
     requester_file_links = dict()
     for file_data in files:
         response_obj = add_file(current_request.id,

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -102,15 +102,14 @@ def response_file(request_id):
     agency_links = []
     requester_links = []
     for file_data in files:
-        add_file(current_request.id,
-                 file_data,
-                 files[file_data]['title'],
-                 files[file_data]['privacy'])
-        response_obj = add_file
+        response_obj = add_file(current_request.id,
+                                file_data,
+                                files[file_data]['title'],
+                                files[file_data]['privacy'])
         agency_link, requester_link = get_file_links(response_obj)
         agency_links.append(agency_link)
-        requester_links.append(requester_link)
-
+        if requester_link is not None:
+            requester_links.append(requester_link)
     file_options = process_privacy_options(files)
     email_content = flask_request.form['email-file-summary']
     send_file_email(request_id, file_options, files, email_content)

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -92,39 +92,23 @@ def response_file(request_id):
     Call process_upload_data to process the uploaded file form data.
     Pass data into helper function in response.utils to update changes into database.
     Send email notification to requester and bcc agency users if privacy is release.
-    Render specific tempalte and send email notification bcc agency users if privacy is private.
+    Render specific template and send email notification bcc agency users if privacy is private.
 
     :param request_id: FOIL request ID for the specific file.
     :return: redirect to view request page
     """
     current_request = Requests.query.filter_by(id=request_id).first()
     files = process_upload_data(flask_request.form)
-    agency_links = []
-    requester_links = []
+    agency_file_links = dict()
+    requester_file_links = dict()
     for file_data in files:
         response_obj = add_file(current_request.id,
                                 file_data,
                                 files[file_data]['title'],
                                 files[file_data]['privacy'])
-        agency_link, requester_link = get_file_links(response_obj)
-        agency_links.append(agency_link)
-        if requester_link is not None:
-            requester_links.append(requester_link)
-    file_options = process_privacy_options(files)
-    email_content = flask_request.form['email-file-summary']
-    send_file_email(request_id, file_options, files, email_content)
-    # for privacy, files in file_options.items():
-    #     if privacy == PRIVATE:
-    #         send_file_email(request_id,
-    #                         privacy,
-    #                         files,
-    #                         None,
-    #                         email_template='email_templates/email_private_file_upload.html')
-    #     else:
-    #         send_file_email(request_id,
-    #                         privacy,
-    #                         files,
-    #                         email_content)
+        agency_file_links, requester_file_links = get_file_links(response_obj, agency_file_links, requester_file_links)
+    email_content = flask_request.form['email-file-content']
+    send_file_email(request_id, agency_file_links, requester_file_links, email_content)
     return redirect(url_for('request.view', request_id=request_id))
 
 

--- a/app/response/views.py
+++ b/app/response/views.py
@@ -40,6 +40,7 @@ from app.response.utils import (
     add_acknowledgment,
     add_denial,
     add_instruction,
+    get_file_links,
     process_upload_data,
     send_file_email,
     process_privacy_options,
@@ -98,25 +99,33 @@ def response_file(request_id):
     """
     current_request = Requests.query.filter_by(id=request_id).first()
     files = process_upload_data(flask_request.form)
+    agency_links = []
+    requester_links = []
     for file_data in files:
         add_file(current_request.id,
                  file_data,
                  files[file_data]['title'],
                  files[file_data]['privacy'])
+        response_obj = add_file
+        agency_link, requester_link = get_file_links(response_obj)
+        agency_links.append(agency_link)
+        requester_links.append(requester_link)
+
     file_options = process_privacy_options(files)
     email_content = flask_request.form['email-file-summary']
-    for privacy, files in file_options.items():
-        if privacy == PRIVATE:
-            send_file_email(request_id,
-                            privacy,
-                            files,
-                            None,
-                            email_template='email_templates/email_private_file_upload.html')
-        else:
-            send_file_email(request_id,
-                            privacy,
-                            files,
-                            email_content)
+    send_file_email(request_id, file_options, files, email_content)
+    # for privacy, files in file_options.items():
+    #     if privacy == PRIVATE:
+    #         send_file_email(request_id,
+    #                         privacy,
+    #                         files,
+    #                         None,
+    #                         email_template='email_templates/email_private_file_upload.html')
+    #     else:
+    #         send_file_email(request_id,
+    #                         privacy,
+    #                         files,
+    #                         email_content)
     return redirect(url_for('request.view', request_id=request_id))
 
 

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -1,7 +1,7 @@
 
 <p>Attention {{ agency_name }} Users,<p>
 
-<p>The following files were uploaded as private to <a href="{{ url_for('request.view', request_id=request_id) }}">{{ request_id }}</a></p>
+<p>The following files were uploaded as private to <a href="{{ url_for('request.view', request_id=request_id) }}">{{ request_id }}</a>:</p>
 
 <ul>
     {% for filename, link in files_links.items() %}

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -13,9 +13,18 @@
 
     {% if agency_file_links %}
         <ul>
-        {% for filename, link in agency_file_links.items() %}
+            Private Files:
+            {% for filename, link in agency_file_links['private'].items() %}
+                <li style="list-style: none"><a href="{{ link }}">{{ filename }}</a></li>
+            {% endfor %}
+        </ul>
+        <p>
+        <ul>
+            Release Files sent to the Requester:
+            {% for filename, link in agency_file_links['release'].items() %}
             <li style="list-style: none"><a href="{{ link }}">{{ filename }}</a></li>
-        {% endfor %}
+            {% endfor %}
+        </p>
         </ul>
     {% else %}
         <ul>

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -2,14 +2,15 @@
     {{ email_file_content | safe}}
 
     <ul>
-        {% for filename, link in agency_file_links.items() %}
+        Private Files:
+        {% for filename, link in agency_file_links['private'].items() %}
             <li style="list-style: none"><a href="{{ link }}">{{ filename }}</a></li>
         {% endfor %}
     </ul>
 {% else %}
     <p>Attention {{ agency_name }} Users,<p>
 
-    <p>The following files were uploaded to <a href="{{ url_for('request.view', request_id=request_id) }}">{{ request_id }}</a>:</p>
+    <p>The following files were uploaded to <a href="{{ page }}">{{ request_id }}</a>:</p>
 
     {% if agency_file_links %}
         <ul>

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -1,4 +1,3 @@
-
 <p>Attention {{ agency_name }} Users,<p>
 
 <p>The following files were uploaded as private to <a href="{{ url_for('request.view', request_id=request_id) }}">{{ request_id }}</a>:</p>

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -14,10 +14,12 @@
 
     {% if agency_file_links %}
         <ul>
-            Private Files:
-            {% for filename, link in agency_file_links['private'].items() %}
-                <li style="list-style: none"><a href="{{ link }}">{{ filename }}</a></li>
-            {% endfor %}
+            {% if agency_file_links['private'].items() %}
+                Private Files:
+                {% for filename, link in agency_file_links['private'].items() %}
+                    <li style="list-style: none"><a href="{{ link }}">{{ filename }}</a></li>
+                {% endfor %}
+            {% endif %}
         </ul>
         <p>
         <ul>

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -1,9 +1,27 @@
-<p>Attention {{ agency_name }} Users,<p>
+{% if email_file_content %}
+    {{ email_file_content | safe}}
 
-<p>The following files were uploaded as private to <a href="{{ url_for('request.view', request_id=request_id) }}">{{ request_id }}</a>:</p>
+    <ul>
+        {% for filename, link in agency_file_links.items() %}
+            <li style="list-style: none"><a href="{{ link }}">{{ filename }}</a></li>
+        {% endfor %}
+    </ul>
+{% else %}
+    <p>Attention {{ agency_name }} Users,<p>
 
-<ul>
-    {% for filename, link in files_links.items() %}
-        <li style="list-style: none"><a href="#">{{ filename }}</a></li>
-    {% endfor %}
-</ul>
+    <p>The following files were uploaded to <a href="{{ url_for('request.view', request_id=request_id) }}">{{ request_id }}</a>:</p>
+
+    {% if agency_file_links %}
+        <ul>
+        {% for filename, link in agency_file_links.items() %}
+            <li style="list-style: none"><a href="{{ link }}">{{ filename }}</a></li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <ul>
+            {% for filename, link in files_links.items() %}
+                <li style="list-style: none"><a href="#">{{ filename }}</a></li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endif %}

--- a/app/templates/email_templates/email_private_file_upload.html
+++ b/app/templates/email_templates/email_private_file_upload.html
@@ -4,6 +4,6 @@
 
 <ul>
     {% for filename, link in files_links.items() %}
-        <li style="list-style: none"><a href='{{ link }}'>{{ filename }}</a></li>
+        <li style="list-style: none"><a href="#">{{ filename }}</a></li>
     {% endfor %}
 </ul>

--- a/app/templates/email_templates/email_response.html
+++ b/app/templates/email_templates/email_response.html
@@ -4,7 +4,7 @@
         information about your Freedom of Information Law (FOIL) ID number <a href='{{ page }}'>{{ request_id }}</a>.
     </p>
     <p>
-        Please visit <a href='{{ page }}'>{{ page }}</a> to view the additional information.
+        Please visit <a href='{{ page }}'>{{ page }}</a> to view additional information and take any necessary action.
     </p>
 {% else %}
     {% if email_file_content %}
@@ -16,8 +16,4 @@
         {% block response_content %}
         {% endblock %}
     {% endif %}
-    <p>
-        You can view the request and take any necessary action at the following webpage:
-        <a href='{{ page }}'>{{ page }}</a>.
-    </p>
 {% endif %}

--- a/app/templates/email_templates/email_response.html
+++ b/app/templates/email_templates/email_response.html
@@ -7,9 +7,15 @@
         Please visit <a href='{{ page }}'>{{ page }}</a> to view the additional information.
     </p>
 {% else %}
-    {{ content | safe }}
-    {% block response_content %}
-    {% endblock %}
+    {% if email_file_content %}
+        {{ email_file_content | safe }}
+        {% block response_file_content %}
+        {% endblock %}
+    {% else %}
+        {{ content | safe }}
+        {% block response_content %}
+        {% endblock %}
+    {% endif %}
     <p>
         You can view the request and take any necessary action at the following webpage:
         <a href='{{ page }}'>{{ page }}</a>.

--- a/app/templates/email_templates/email_response_file.html
+++ b/app/templates/email_templates/email_response_file.html
@@ -1,16 +1,45 @@
 {% extends 'email_templates/email_response.html' %}
-{% block response_content %}
-    {% if files_links %}
-    <p>
-        Download the request files at:
-        <br>
-        <ul>
-            {% for filename, link in files_links.items() %}
-                <li style="list-style: none">
-                    <a href="#">{{ filename }}</a>
-                </li>
-            {% endfor %}
-        </ul>
-    </p>
+{% block response_file_content %}
+    {% if email_file_content %}
+        {% if requester_file_links %}
+            {% if is_anon %}
+                <p>
+                You have 20 DAYS to download the following request files:
+                <br>
+                <ul>
+                    {% for filename, link in requester_file_links.items() %}
+                        <li style="list-style: none">
+                            {{ filename }}: <a href="{{ link }}">{{ link }}</a>
+                        </li>
+                    {% endfor %}
+            {% else %}
+                <p>
+                Download the request files at:
+                <br>
+                <ul>
+                    {% for filename, link in requester_file_links.items() %}
+                        <li style="list-style: none">
+                            <a href="{{ link }}">{{ filename }}</a>
+                        </li>
+                    {% endfor %}
+            {% endif %}
+            </ul>
+        </p>
+        {% endif %}
     {% endif %}
 {% endblock %}
+    {% block response_content %}
+        {% if files_links %}
+        <p>
+            Download the request files at:
+            <br>
+            <ul>
+                {% for filename, link in files_links.items() %}
+                    <li style="list-style: none">
+                        <a href="#">{{ filename }}</a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </p>
+        {% endif %}
+    {% endblock %}

--- a/app/templates/email_templates/email_response_file.html
+++ b/app/templates/email_templates/email_response_file.html
@@ -7,7 +7,7 @@
         <ul>
             {% for filename, link in files_links.items() %}
                 <li style="list-style: none">
-                    <a href='{{ link }}'>{{ filename }}</a>
+                    <a href="#">{{ filename }}</a>
                 </li>
             {% endfor %}
         </ul>

--- a/app/templates/response/add_file.html
+++ b/app/templates/response/add_file.html
@@ -11,11 +11,11 @@
                 <!-- first div of the add-file form containing uploads -->
                 <div class="row fileupload-buttonbar">
                     <div class="col-lg-7">
-                            <span class="btn btn-success fileinput-button">
-                                <i class="glyphicon glyphicon-plus"></i>
-                                <span>Add files...</span>
-                                <input type="file" name="file" id="add-files" multiple>
-                            </span>
+                        <span class="btn btn-success fileinput-button">
+                            <i class="glyphicon glyphicon-plus"></i>
+                            <span>Add files...</span>
+                            <input type="file" name="file" id="add-files" multiple>
+                        </span>
                         <button type="submit" class="btn btn-primary start">
                             <i class="glyphicon glyphicon-upload"></i>
                             <span>Start All</span>

--- a/app/templates/response/add_file.html
+++ b/app/templates/response/add_file.html
@@ -6,16 +6,16 @@
             <legend>
                 Add File
             </legend>
-            <div class="fileupload-error-messages"></div>
-            <!-- first div of the add-file form containing uploads -->
-            <div class="fileupload-divs" id="fileupload-first">
+            <div class="first">
+                <div class="fileupload-error-messages"></div>
+                <!-- first div of the add-file form containing uploads -->
                 <div class="row fileupload-buttonbar">
                     <div class="col-lg-7">
-                        <span class="btn btn-success fileinput-button">
-                            <i class="glyphicon glyphicon-plus"></i>
-                            <span>Add files...</span>
-                            <input type="file" name="file" id="add-files" multiple>
-                        </span>
+                            <span class="btn btn-success fileinput-button">
+                                <i class="glyphicon glyphicon-plus"></i>
+                                <span>Add files...</span>
+                                <input type="file" name="file" id="add-files" multiple>
+                            </span>
                         <button type="submit" class="btn btn-primary start">
                             <i class="glyphicon glyphicon-upload"></i>
                             <span>Start All</span>
@@ -47,25 +47,25 @@
                 <div role="presentation">
                     <div class="files"></div>
                 </div>
-                <button type="button" class="next-btn btn btn-primary" id="fileupload-next-1">Next</button>
+                <button type="button" class="next next-btn btn btn-primary">Next</button>
             </div>
             <!-- second div of the add-file form containing email content -->
-            <div class="fileupload-divs hide-div" id="fileupload-second">
+            <div class="second" hidden>
                 <div class='alert alert-warning'>
                     Files made Release and Public or Release and Private will be shown with links on the next page.
                 </div>
                 <textarea class="tinymce-area" name="email-file-content" title="email-content"></textarea>
-                <button type="button" class="prev-btn btn btn-default" id="fileupload-prev-1">Prev</button>
-                <button type="button" class="next-btn btn btn-primary" id="fileupload-next-2">Next</button>
+                <button type="button" class="prev prev-btn btn btn-default">Prev</button>
+                <button type="button" class="next next-btn btn btn-primary">Next</button>
             </div>
             <!-- last div of the add-file form containing confirmation and submit -->
-            <div class="fileupload-divs hide-div" id="fileupload-third">
+            <div class="third" hidden>
                 <h4>The following will be Submitted to the request:</h4>
                 <h5>Email:</h5>
                 <div class="wrap-text" id="email-file-summary"></div>
                 <!-- hidden input to send email summary to backend -->
                 <input type="hidden" name="email-file-summary" id="email-file-summary-hidden">
-                <button type="button" class="prev-btn btn btn-default" id="fileupload-prev-2">Prev</button>
+                <button type="button" class="prev pull-left btn btn-default">Prev</button>
                 <button type="submit" class="submit-btn btn btn-success" id="file-submit">Submit</button>
             </div>
             </fieldset>

--- a/app/templates/response/add_file.html
+++ b/app/templates/response/add_file.html
@@ -7,7 +7,7 @@
                 Add File
             </legend>
             <div class="first">
-                <div class="fileupload-error-messages"></div>
+                <div class="fileupload-error-messages alert alert-danger" hidden></div>
                 <!-- first div of the add-file form containing uploads -->
                 <div class="row fileupload-buttonbar">
                     <div class="col-lg-7">

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -1,54 +1,64 @@
 <script type="text/javascript">
     $(function () {
-        // Hides all other divs except for the first. Also hides previous button on the first div.
-        $(".fileupload-control .fileupload-divs").each(function (e) {
-            if (e != 0)
-                $(this).hide();
-            else
-                $("#previous").hide();
-        });
+        var form = $(".fileupload-form");
+        var first = form.find(".first");
+        var second = form.find(".second");
+        var third = form.find(".third");
 
+        var next1 = first.find(".next");
+        var next2 = second.find(".next");
+        var prev2 = second.find(".prev");
+        var prev3 = third.find(".prev");
+
+        var addFile = first.find("#add-files");
+        var errorMessage = first.find(".fileupload-error-messages");
+
+        // Apply parsley required validation
+        addFile.attr('data-parsley-required', 'false');
+
+        // Apply parsley error message to a specific container
+        addFile.attr('data-parsley-errors-container', '.fileupload-buttonbar');
 
         // Handles click events on the first next button
-        $("#fileupload-next-1").click(function (e) {
+        next1.click(function (e) {
             // Validate file input field and file form
-            $('#fileupload').parsley().validate();
+            form.parsley().validate();
 
             // Removes parsley validator on file input field when a file has been successfully uploaded
-            if ($('.template-download').length > 0) {
-                $('#add-files').attr('data-parsley-required', 'false');
+            if (first.find(".template-download").length > 0) {
+                addFile.attr('data-parsley-required', 'false');
             }
 
             // Prevent default if one more more upload has not been completed
-            if ($('.template-download').length === 0 && ($('.template-upload').length != 0)) {
-                $('.fileupload-error-messages').html("<div class='alert alert-danger'>One or more uploads has not completed</div>");
+            if (first.find(".template-download").length === 0 && (first.find(".template-upload").length != 0)) {
+                errorMessage.html("<div class='alert alert-danger'>One or more uploads has not completed</div>");
                 e.preventDefault();
                 return false;
             }
 
             // Prevent default if no file has been added or uploaded
-            if ($('.template-download').length === 0 && ($('.template-upload').length === 0)) {
-                $('.fileupload-error-messages').html("<div class='alert alert-danger'>A file must be added</div>");
+            if (first.find(".template-download").length === 0 && (first.find(".template-upload").length === 0)) {
+                errorMessage.html("<div class='alert alert-danger'>A file must be added</div>");
                 e.preventDefault();
                 return false;
             }
 
             // Prevent default if files with error are not removed
             if ($('.upload-error').length > 0 || $(".error-post-fileupload").is(':visible')) {
-                $('.fileupload-error-messages').html("<div class='alert alert-danger'>Files with Errors must be removed</div>");
+                errorMessage.html("<div class='alert alert-danger'>Files with Errors must be removed</div>");
                 e.preventDefault();
                 return false;
             }
 
             // Prevent default if fileupload form is in NOT valid
-            if (!$('#fileupload').parsley().isValid()) {
+            if (!form.parsley().isValid()) {
                 e.preventDefault();
                 return false;
             }
 
             // Proceed with next click function if validation fields are valid and no files are uploading
-            if ($("#fileupload").parsley().isValid() && ($('.template-upload').length === 0)) {
-                $('.fileupload-error-messages').html('');
+            if (form.parsley().isValid() && (first.find(".template-upload").length === 0)) {
+                errorMessage.html('');
                 var privacy = $(".file-privacy:checked").map(function(){return $(this).val(); }).get();
                 var is_private;
                 for (var i = 0; i < privacy.length; i++) {
@@ -60,6 +70,7 @@
                         break;
                     }
                 }
+                console.log(is_private);
                 $.ajax({
                     url: "/response/email",
                     type: 'POST',
@@ -74,19 +85,15 @@
                         tinyMCE.get('email-file-content').setContent(data.template);
                     }
                 });
-                document.getElementById("fileupload-first").style.display = "none";
-                document.getElementById("fileupload-second").style.display = "block";
+                first.hide();
+                second.show();
             }
         });
 
         // Handles click events on the second next button
-        $("#fileupload-next-2").click(function () {
+        next2.click(function () {
             $('.fileupload-error-messages').html('');
             tinyMCE.triggerSave();
-
-            // Get list of both secured filenames and privacy option values, and store them into variables
-            var filenames = $('.secured-name').map( function(){return $(this).text(); }).get();
-            var privacy = $(".file-privacy:checked").map( function(){return $(this).val(); }).get();
 
             // Create an array (called files) of objects with keys of filename and privacy
             var files = [];
@@ -114,21 +121,21 @@
                     $("#email-file-summary-hidden").val(data.template);
                 }
             });
-            document.getElementById("fileupload-second").style.display = "none";
-            document.getElementById("fileupload-third").style.display = "block";
+            second.hide();
+            third.show();
         });
 
         // Handles click events on the first previous button
-        $("#fileupload-prev-1").click(function () {
+        prev2.click(function () {
             $('.fileupload-error-messages').html('');
-            document.getElementById("fileupload-first").style.display = "block";
-            document.getElementById("fileupload-second").style.display = "none";
+            second.hide();
+            first.show();
         });
 
         // Handles click events on the second previous button
-        $("#fileupload-prev-2").click(function () {
-            document.getElementById("fileupload-third").style.display = "none";
-            document.getElementById("fileupload-second").style.display = "block";
+        prev3.click(function () {
+            third.hide();
+            second.show();
         });
 
         // Disable button on submit click and submit form
@@ -136,12 +143,6 @@
             $(this).attr("disabled", true);
             $("#fileupload").submit();
         });
-
-        // Apply parsley required validation
-        $('#add-files').attr('data-parsley-required', 'false');
-
-        // Apply parsley error message to a specific container
-        $('#add-files').attr('data-parsley-errors-container', '.fileupload-buttonbar');
 
         // Initialize tinymce HTML editor
         tinymce.init({

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -20,7 +20,7 @@
         // Apply parsley error message to a specific container
         addFile.attr('data-parsley-errors-container', '.fileupload-buttonbar');
 
-        var is_private;
+        var is_private = true;
 
         // Handles click events on the first next button
         next1.click(function (e) {
@@ -70,9 +70,7 @@
                 var privacy = first.find(".file-privacy:checked").map(function(){return $(this).val(); }).get();
                 for (var i = 0; i < privacy.length; i++) {
                     // Check if current value === 'private'
-                    if (privacy[i] === 'private') {
-                        is_private = true;
-                    } else {
+                    if (privacy[i] !== 'private') {
                         is_private = false;
                         break;
                     }

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -20,6 +20,8 @@
         // Apply parsley error message to a specific container
         addFile.attr('data-parsley-errors-container', '.fileupload-buttonbar');
 
+        var is_private;
+
         // Handles click events on the first next button
         next1.click(function (e) {
             var templateDownload = first.find(".template-download");
@@ -66,7 +68,6 @@
             // Proceed with next click function if validation fields are valid and no files are uploading
             if (form.parsley().isValid() && (templateUpload.length === 0)) {
                 var privacy = first.find(".file-privacy:checked").map(function(){return $(this).val(); }).get();
-                var is_private;
                 for (var i = 0; i < privacy.length; i++) {
                     // Check if current value === 'private'
                     if (privacy[i] === 'private') {
@@ -120,7 +121,8 @@
                     template_name: "email_response_file.html",
                     type: "files",
                     files: JSON.stringify(files),
-                    email_content: second.find("#email-file-content").val()
+                    email_content: second.find("#email-file-content").val(),
+                    is_private: is_private
                 },
                 success: function (data) {
                     // Data should be html template page.

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -1,7 +1,5 @@
 <script type="text/javascript">
     $(function () {
-{#        var form = $("#fileupload");#}
-
         // Hides all other divs except for the first. Also hides previous button on the first div.
         $(".fileupload-control .fileupload-divs").each(function (e) {
             if (e != 0)
@@ -52,10 +50,15 @@
             if ($("#fileupload").parsley().isValid() && ($('.template-upload').length === 0)) {
                 $('.fileupload-error-messages').html('');
                 var privacy = $(".file-privacy:checked").map(function(){return $(this).val(); }).get();
-                for (var i = 1; i < privacy.length; i++) {
-                    var is_private = privacy[i] === privacy[0];
-                    if (is_private && privacy[0] === 'private')
+                var is_private;
+                for (var i = 0; i < privacy.length; i++) {
+                    // 1. Check if current value === 'private'
+                    if (privacy[i] === 'private') {
                         is_private = true;
+                    } else {
+                        is_private = false;
+                        break;
+                    }
                 }
                 $.ajax({
                     url: "/response/email",

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -9,6 +9,7 @@
         var next2 = second.find(".next");
         var prev2 = second.find(".prev");
         var prev3 = third.find(".prev");
+        var submit = third.find("#file-submit");
 
         var addFile = first.find("#add-files");
         var errorMessage = first.find(".fileupload-error-messages");
@@ -21,31 +22,37 @@
 
         // Handles click events on the first next button
         next1.click(function (e) {
+            var templateDownload = first.find(".template-download");
+            var templateUpload = first.find(".template-upload");
+            var uploadError = first.find(".upload-error");
+            var errorPostUpload = first.find(".error-post-fileupload");
+
+
             // Validate file input field and file form
             form.parsley().validate();
 
             // Removes parsley validator on file input field when a file has been successfully uploaded
-            if (first.find(".template-download").length > 0) {
+            if (templateDownload.length > 0) {
                 addFile.attr('data-parsley-required', 'false');
             }
 
             // Prevent default if one more more upload has not been completed
-            if (first.find(".template-download").length === 0 && (first.find(".template-upload").length != 0)) {
-                errorMessage.html("<div class='alert alert-danger'>One or more uploads has not completed</div>");
+            if (templateDownload.length === 0 && (templateUpload.length != 0)) {
+                errorMessage.text("One or more uploads has not completed").show();
                 e.preventDefault();
                 return false;
             }
 
             // Prevent default if no file has been added or uploaded
-            if (first.find(".template-download").length === 0 && (first.find(".template-upload").length === 0)) {
-                errorMessage.html("<div class='alert alert-danger'>A file must be added</div>");
+            if (templateDownload.length === 0 && (templateUpload.length === 0)) {
+                errorMessage.text("A file must be added").show();
                 e.preventDefault();
                 return false;
             }
 
             // Prevent default if files with error are not removed
-            if ($('.upload-error').length > 0 || $(".error-post-fileupload").is(':visible')) {
-                errorMessage.html("<div class='alert alert-danger'>Files with Errors must be removed</div>");
+            if (uploadError.length > 0 || errorPostUpload.is(':visible')) {
+                errorMessage.text("Files with Errors must be removed").show();
                 e.preventDefault();
                 return false;
             }
@@ -57,12 +64,11 @@
             }
 
             // Proceed with next click function if validation fields are valid and no files are uploading
-            if (form.parsley().isValid() && (first.find(".template-upload").length === 0)) {
-                errorMessage.html('');
-                var privacy = $(".file-privacy:checked").map(function(){return $(this).val(); }).get();
+            if (form.parsley().isValid() && (templateUpload.length === 0)) {
+                var privacy = first.find(".file-privacy:checked").map(function(){return $(this).val(); }).get();
                 var is_private;
                 for (var i = 0; i < privacy.length; i++) {
-                    // 1. Check if current value === 'private'
+                    // Check if current value === 'private'
                     if (privacy[i] === 'private') {
                         is_private = true;
                     } else {
@@ -70,7 +76,6 @@
                         break;
                     }
                 }
-                console.log(is_private);
                 $.ajax({
                     url: "/response/email",
                     type: 'POST',
@@ -92,8 +97,10 @@
 
         // Handles click events on the second next button
         next2.click(function () {
-            $('.fileupload-error-messages').html('');
             tinyMCE.triggerSave();
+
+            var filenames = first.find(".secured-name").map( function(){return $(this).text(); }).get();
+            var privacy = first.find(".file-privacy:checked").map(function(){return $(this).val(); }).get();
 
             // Create an array (called files) of objects with keys of filename and privacy
             var files = [];
@@ -113,12 +120,12 @@
                     template_name: "email_response_file.html",
                     type: "files",
                     files: JSON.stringify(files),
-                    email_content: $('#email-file-content').val()
+                    email_content: second.find("#email-file-content").val()
                 },
                 success: function (data) {
                     // Data should be html template page.
-                    $("#email-file-summary").html(data.template);
-                    $("#email-file-summary-hidden").val(data.template);
+                    third.find("#email-file-summary").html(data.template);
+                    third.find("#email-file-summary-hidden").val(data.template);
                 }
             });
             second.hide();
@@ -127,7 +134,7 @@
 
         // Handles click events on the first previous button
         prev2.click(function () {
-            $('.fileupload-error-messages').html('');
+            errorMessage.hide();
             second.hide();
             first.show();
         });
@@ -139,9 +146,9 @@
         });
 
         // Disable button on submit click and submit form
-        $("#file-submit").click(function () {
+        submit.click(function () {
             $(this).attr("disabled", true);
-            $("#fileupload").submit();
+            form.submit();
         });
 
         // Initialize tinymce HTML editor

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -37,7 +37,7 @@
             }
 
             // Prevent default if one more more upload has not been completed
-            if (templateDownload.length === 0 && (templateUpload.length != 0)) {
+            if (templateDownload.length === 0 && (templateUpload.length !== 0)) {
                 errorMessage.text("One or more uploads has not completed").show();
                 e.preventDefault();
                 return false;

--- a/app/templates/response/add_file.js.html
+++ b/app/templates/response/add_file.js.html
@@ -1,5 +1,7 @@
 <script type="text/javascript">
-    $(document).ready(function () {
+    $(function () {
+{#        var form = $("#fileupload");#}
+
         // Hides all other divs except for the first. Also hides previous button on the first div.
         $(".fileupload-control .fileupload-divs").each(function (e) {
             if (e != 0)
@@ -7,6 +9,7 @@
             else
                 $("#previous").hide();
         });
+
 
         // Handles click events on the first next button
         $("#fileupload-next-1").click(function (e) {
@@ -48,13 +51,20 @@
             // Proceed with next click function if validation fields are valid and no files are uploading
             if ($("#fileupload").parsley().isValid() && ($('.template-upload').length === 0)) {
                 $('.fileupload-error-messages').html('');
+                var privacy = $(".file-privacy:checked").map(function(){return $(this).val(); }).get();
+                for (var i = 1; i < privacy.length; i++) {
+                    var is_private = privacy[i] === privacy[0];
+                    if (is_private && privacy[0] === 'private')
+                        is_private = true;
+                }
                 $.ajax({
                     url: "/response/email",
                     type: 'POST',
                     data: {
                         request_id: "{{ request.id }}",
                         template_name: "email_response_file.html",
-                        type: "files"
+                        type: "files",
+                        is_private: is_private
                     },
                     success: function (data) {
                         // Data should be html template page.


### PR DESCRIPTION
- Refactored frontend `add_file.html` and` add_file.js.html`
- Implemented check for if all uploaded files are private in `add_file.js.html`
- Private file response email template is rendered if all file privacies are private.
- Created function `get_file_links` in `response.utils` to get live file links to be sent in email notification
- Updated email templates to reflect changes of rerendering on submit.