### PR TITLE
Bugfix/OP-970: Appeals Text Missing from Closing and Denial

### DIFF
--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -493,6 +493,7 @@ def _denial_email_handler(request_id, data, page, agency_name, email_template):
         agency_name=agency_name,
         reasons=[Reasons.query.filter_by(id=reason_id).one().content
                  for reason_id in data.getlist('reason_ids[]')],
+        agency_appeals_email=Requests.query.filter_by(id=request_id).first().agency.appeals_email,
         page=page
     )}), 200
 
@@ -524,6 +525,7 @@ def _closing_email_handler(request_id, data, page, agency_name, email_template):
         request_id=request_id,
         agency_name=agency_name,
         reasons=reasons,
+        agency_appeals_email=Requests.query.filter_by(id=request_id).first().agency.appeals_email,
         page=page
     )}), 200
 
@@ -843,9 +845,9 @@ def _get_edit_response_template(editor):
                                                       page=page,
                                                       privacy=data['privacy'],
                                                       response_privacy=response_privacy)
-        if release_and_viewable:
+        if was_private:
             recipient = "all associated participants"
-        elif was_private:
+        elif release_and_viewable:
             recipient = "the Requester"
         else:
             recipient = "all Assigned Users"

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -493,7 +493,7 @@ def _denial_email_handler(request_id, data, page, agency_name, email_template):
         agency_name=agency_name,
         reasons=[Reasons.query.filter_by(id=reason_id).one().content
                  for reason_id in data.getlist('reason_ids[]')],
-        agency_appeals_email=Requests.query.filter_by(id=request_id).first().agency.appeals_email,
+        agency_appeals_email=Requests.query.filter_by(id=request_id).one().agency.appeals_email,
         page=page
     )}), 200
 
@@ -525,7 +525,7 @@ def _closing_email_handler(request_id, data, page, agency_name, email_template):
         request_id=request_id,
         agency_name=agency_name,
         reasons=reasons,
-        agency_appeals_email=Requests.query.filter_by(id=request_id).first().agency.appeals_email,
+        agency_appeals_email=Requests.query.filter_by(id=request_id).one().agency.appeals_email,
         page=page
     )}), 200
 

--- a/app/templates/email_templates/email_response_closing.html
+++ b/app/templates/email_templates/email_response_closing.html
@@ -15,4 +15,9 @@
             {% endfor %}
         </ul>
     {% endif %}
+    <p>
+        You may appeal the decision to deny access to material that was redacted in part or withheld in entirety
+        by contacting the agency's FOIL Appeals Officer: <a href="mailto:{{ agency_appeals_email }}">{{ agency_appeals_email }}</a>
+        within 30 days.
+    </p>
 {% endif %}

--- a/app/templates/email_templates/email_response_denial.html
+++ b/app/templates/email_templates/email_response_denial.html
@@ -10,3 +10,8 @@
         <li>{{ reason }}</li>
     {% endfor %}
 </ul>
+<p>
+    You may appeal the decision to deny access to material that was redacted in part or withheld in entirety
+    by contacting the agency's FOIL Appeals Officer: <a href="mailto:{{ agency_appeals_email }}">{{ agency_appeals_email }}</a>
+    within 30 days.
+</p>


### PR DESCRIPTION
- Added appeals text to closing and denial emails
- Updated check for edit response email header to check `was_private` before `release_and_viewable`