### PR TITLE
bugfix/OP-973: remove category & date field keydown

### DIFF
--- a/app/request/forms.py
+++ b/app/request/forms.py
@@ -82,7 +82,6 @@ class AgencyUserRequestForm(Form):
     """
 
     # Request Information
-    request_category = SelectField('Category (optional)', choices=CATEGORIES)
     request_title = StringField('Request Title (required)')
     request_description = TextAreaField('Request Description (required)')
     request_date = DateTimeField("Date (required)", format="%Y-%m-%d", default=datetime.today)

--- a/app/request/views.py
+++ b/app/request/views.py
@@ -180,6 +180,7 @@ def view(request_id):
 
     :return: redirect to view request page
     """
+    # FIXME: 404 if agency not active?
     current_request = Requests.query.filter_by(id=request_id).one()
 
     holidays = sorted(get_holidays_date_list(

--- a/app/request/views.py
+++ b/app/request/views.py
@@ -109,7 +109,7 @@ def new():
         elif current_user.is_agency:
             request_id = create_request(form.request_title.data,
                                         form.request_description.data,
-                                        form.request_category.data,
+                                        category=None,
                                         agency=current_user.agency_ein,
                                         submission=form.method_received.data,
                                         agency_date_submitted=form.request_date.data,

--- a/app/static/js/request/new-request-agency.js
+++ b/app/static/js/request/new-request-agency.js
@@ -57,7 +57,7 @@ $(document).ready(function () {
     // Datepicker for date request was received when creating a new request
     $(".dtpick").datepicker({
         dateFormat: "yy-mm-dd"
-    });
+    }).keydown(false);
 
     // Loop through required fields and apply a data-parsley-required attribute to them
     var required_fields = ['request-title','request-description', 'request-agency', 'first-name','last-name','email',

--- a/app/templates/request/new_request_agency.html
+++ b/app/templates/request/new_request_agency.html
@@ -19,13 +19,6 @@
                     notify
                     you about how much time is required to
                     respond to your request.</p>
-                {# Categories to filter out agencies #}
-                {{ form.request_category.label(class='request-heading') }}
-                <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Category Field"
-                      data-content="Selecting a category helps clarify which agency will receive the request"
-                      class="glyphicon glyphicon-question-sign">
-                </span>
-                {{ form.request_category(id='request-category', class='input-block-level') }}<br>
                 {# Title of the request #}
                 {{ form.request_title.label(class='request-heading') }}
                 <span data-toggle="popover" data-placement="right" data-trigger="hover" title="Title Field"
@@ -36,8 +29,10 @@
                         placeholder='Please provide a short summary of your request.', maxlength="90") }}
                 <h5 id="title-character-count">90 characters remaining</h5>
                 <div class="alert alert-info">
-                    <p><b>Note: The agency, category, and topic of your request will be visible to the public. Do not
-                            enter personal information here.</b></p>
+                    <p><strong>
+                        Note: The title of this request will be visible to the public.
+                        Do not enter personal information here.
+                    </strong></p>
                 </div>
                 {# Description of the request #}
                 {{ form.request_description.label(class='request-heading') }}
@@ -50,7 +45,8 @@
                         maxlength="5000") }}
                 <h5 id="description-character-count">5000 characters remaining</h5>
                 <div class="alert alert-info">
-                    <p><b>Note: The request details you write here will not be visible to the public. However, the agency may post a description of the records provided.</b></p>
+                    <p><b>Note: The request details written here will not be visible to the public.
+                        However, your agency may post a description of the records provided.</b></p>
                 </div>
 
                 {# Upload field for user to add files #}

--- a/app/templates/response/add_acknowledgment.js.html
+++ b/app/templates/response/add_acknowledgment.js.html
@@ -34,7 +34,7 @@
             dateFormat: "yy-mm-dd",
             daysOfWeekDisabled: [0, 6],
             beforeShowDay: notHolidayOrWeekend,
-            minDate: "{{ request.due_date }}".split()[0]
+            minDate: "{{ request.due_date }}".split(' ')[0]
         });
         date.keydown(false);
 


### PR DESCRIPTION
### Should we show a 404 page if someone attempts to view a request (using the address bar, not View Requests as it won't be indexed) that is tied to an inactive agency?