### PR TITLE
Bugfix/OP-1024: Email character count on the request page

### DIFF
--- a/app/static/js/request/contact.js
+++ b/app/static/js/request/contact.js
@@ -17,6 +17,7 @@ $(document).ready(function () {
 
     // Specify length requirement of certain fields
     name.attr('data-parsley-maxlength', 32);
+    email.attr("data-parsley-maxlength", 254);
     subject.attr('data-parsley-maxlength', 90);
     message.attr('data-parsley-maxlength', 5000);
 

--- a/app/static/js/request/edit_requester_info.js
+++ b/app/static/js/request/edit_requester_info.js
@@ -71,6 +71,7 @@ $(function () {
             required[i].attr("data-parsley-required", "");
             required[i].attr("data-parsley-required-message", "");
         }
+        email.attr("data-parsley-maxlength", 254);
         zipCode.attr("data-parsley-length", "[5,5]");
         telephone.attr("data-parsley-length", "[14,14]");
         fax.attr("data-parsley-length", "[14,14]");

--- a/app/templates/main/contact.html
+++ b/app/templates/main/contact.html
@@ -17,7 +17,7 @@
         <h5 id="name-character-count">32 characters remaining</h5>
         <br>
         <label for="email">Email</label>
-        <input id="email" class="form-control" name="email" type="email">
+        <input id="email" class="form-control" name="email" maxlength="254" type="email">
         <br>
         <label for="subject">Subject</label>
         <input id="subject" class="form-control" name="subject" maxlength="90" type="text">

--- a/app/templates/request/_edit_requester_info.html
+++ b/app/templates/request/_edit_requester_info.html
@@ -23,7 +23,7 @@
                     <div id="requester-name">{{ request.requester.name }}</div>
                     <div class="contact-form-error-message"></div>
                     {{ edit_requester_form.email.label }}
-                    {{ edit_requester_form.email(id='inputEmail', type='email', class='form-control') }}
+                    {{ edit_requester_form.email(id='inputEmail', type='email', class='form-control', maxlength="254") }}
 
                     {{ edit_requester_form.title.label }}
                     {{ edit_requester_form.title(id='inputTitle', class='form-control') }}


### PR DESCRIPTION
Set 254 character limit to email input for contact page and edit requester modal