### PR TITLE
Bugfix/OP-1044: Edit FIle shows two links to the file in outgoing email

### DIFF
--- a/app/templates/email_templates/email_edit_file.html
+++ b/app/templates/email_templates/email_edit_file.html
@@ -78,20 +78,6 @@
             </p>
             </div>
             <br>
-
-            {% if not agency %}
-                {% if response_data.response.request.requester.is_anonymous_requester %}
-                    <p>
-                        Link to file: <a href="{{ response_data.file_link_for_user['requester'] }}">
-                        {% if response_data.data_new['name'] %}
-                            {{ response_data.data_new['name'] }}
-                        {% else %}
-                            {{ response_data.response.name }}</a>
-                        {% endif %}
-                    </p>
-                {% endif %}
-            {% endif %}
         {% endif %}
-
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixed edit file to show only one link to file