### PR TITLE
bugfix/OP-1057: Update Close Request flashed error messages

### DIFF
--- a/app/lib/utils.py
+++ b/app/lib/utils.py
@@ -21,7 +21,7 @@ class UserRequestException(Exception):
         :param request_id: request that was not closed
         """
         super(UserRequestException, self).__init__(
-            'Unable to {} request: {}\nReason: {}.'.format(action, request_id, reason)
+            'Unable to {} request: {}\nReason: {}'.format(action, request_id, reason)
         )
 
 

--- a/app/lib/utils.py
+++ b/app/lib/utils.py
@@ -21,7 +21,7 @@ class UserRequestException(Exception):
         :param request_id: request that was not closed
         """
         super(UserRequestException, self).__init__(
-            'Unable to {} request: {}\nReason: {}'.format(action, request_id, reason)
+            'Unable to {} request: {}\nReason: {}.'.format(action, request_id, reason)
         )
 
 

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -225,12 +225,12 @@ def add_closing(request_id, reason_ids, email_content):
                 if privacy[0] != RELEASE_AND_PUBLIC:
                     raise UserRequestException(action="close",
                                                request_id=current_request.id,
-                                               reason=reason + "or all Responses must be public"
+                                               reason=reason + "or all Responses must be public."
                                                )
             if current_request.privacy['title']:
                 raise UserRequestException(action="close",
                                            request_id=current_request.id,
-                                           reason=reason + "or Title must be public"
+                                           reason=reason + "or Title must be public."
                                            )
         update_object(
             {'status': request_status.CLOSED},

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -219,17 +219,18 @@ def add_closing(request_id, reason_ids, email_content):
     current_request = Requests.query.filter_by(id=request_id).one()
     if current_request.status != request_status.CLOSED:
         if current_request.privacy['agency_description'] or not current_request.agency_description:
+            reason = "Agency Description must be public and not empty, "
             for privacy in current_request.responses.with_entities(Responses.privacy, Responses.type).filter(
                             Responses.type != response_type.NOTE, Responses.type != response_type.EMAIL).all():
                 if privacy[0] != RELEASE_AND_PUBLIC:
                     raise UserRequestException(action="close",
                                                request_id=current_request.id,
-                                               reason="Agency Description is private and responses are not public"
+                                               reason=reason + "or all Responses must be public"
                                                )
             if current_request.privacy['title']:
                 raise UserRequestException(action="close",
                                            request_id=current_request.id,
-                                           reason="Agency Description is private and title is private"
+                                           reason=reason + "or Title must be public"
                                            )
         update_object(
             {'status': request_status.CLOSED},


### PR DESCRIPTION
- Updated flashed error messages for Close Request to better reflect the parameters for closing (agency description must be public and not empty, and either all Responses must be public or Title must be public)