### PR TITLE
Bugfix/OP-1059: Fixes to close request and reports

### DIFF
--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -220,16 +220,17 @@ def add_closing(request_id, reason_ids, email_content):
     if current_request.status != request_status.CLOSED:
         if current_request.privacy['agency_description'] or not current_request.agency_description:
             reason = "Agency Description must be public and not empty, "
-            for response in current_request.responses.filter(
-                            Responses.type != response_type.NOTE,
-                            Responses.type != response_type.EMAIL,
-                            Responses.deleted == False).all():
-                if response.privacy != RELEASE_AND_PUBLIC and not (
-                                response.type == response_type.FILE and not response.is_editable):
-                    raise UserRequestException(action="close",
-                                               request_id=current_request.id,
-                                               reason=reason + "or all Responses must be public."
-                                               )
+            if current_request.responses.filter(
+                Responses.type != response_type.NOTE,  # ignore Notes
+                Responses.type != response_type.EMAIL,  # ignore Emails
+                Responses.deleted == False,  # ignore deleted responses
+                Responses.privacy != RELEASE_AND_PUBLIC,  # ignore public responses
+                Responses.is_editable == True  # ignore non-editable responses
+            ).first() is not None:
+                raise UserRequestException(action="close",
+                                           request_id=current_request.id,
+                                           reason=reason + "or all Responses (excluding Notes) must be public."
+                                           )
             if current_request.privacy['title']:
                 raise UserRequestException(action="close",
                                            request_id=current_request.id,

--- a/app/response/utils.py
+++ b/app/response/utils.py
@@ -220,9 +220,12 @@ def add_closing(request_id, reason_ids, email_content):
     if current_request.status != request_status.CLOSED:
         if current_request.privacy['agency_description'] or not current_request.agency_description:
             reason = "Agency Description must be public and not empty, "
-            for privacy in current_request.responses.with_entities(Responses.privacy, Responses.type).filter(
-                            Responses.type != response_type.NOTE, Responses.type != response_type.EMAIL).all():
-                if privacy[0] != RELEASE_AND_PUBLIC:
+            for response in current_request.responses.filter(
+                            Responses.type != response_type.NOTE,
+                            Responses.type != response_type.EMAIL,
+                            Responses.deleted == False).all():
+                if response.privacy != RELEASE_AND_PUBLIC and not (
+                                response.type == response_type.FILE and not response.is_editable):
                     raise UserRequestException(action="close",
                                                request_id=current_request.id,
                                                reason=reason + "or all Responses must be public."

--- a/app/templates/report/reports.js.html
+++ b/app/templates/report/reports.js.html
@@ -53,7 +53,7 @@
     }
 
     $.ajax({
-        url: "/report",
+        url: "/report/",
         type: "GET",
         data: {
             agency_ein: agencyFilter.val()
@@ -80,7 +80,7 @@
 
     agencyFilter.change(function () {
         $.ajax({
-            url: "/report",
+            url: "/report/",
             type: "GET",
             data: {
                 agency_ein: $(this).val()
@@ -119,7 +119,7 @@
             // set agencyEin to value of selected agency if no user is selected
             var agencyEin = agencyUserFilter.val() === '' ? agencyFilter.val() : '';
             $.ajax({
-                url: "/report",
+                url: "/report/",
                 type: "GET",
                 data: {
                     user_guid: $(this).val(),

--- a/app/templates/report/reports.js.html
+++ b/app/templates/report/reports.js.html
@@ -129,6 +129,9 @@
                     for (var i = 0; i < (data.values).length; ++i) {
                         reportChart.data.datasets[0].data[i] = data.values[i]
                     }
+                    var maxTicks = Math.min(Math.max.apply(null, data.values), 10);
+                    reportChart.options.scales.yAxes[0].ticks.maxTicksLimit = 10;
+                    reportChart.options.scales.yAxes[0].ticks.stepSize = maxTicks < 10 ? 1 : false;
                     reportChart.update();
                 }
             })


### PR DESCRIPTION
- Files added by anonymous users should not be factored in as a parameter for closing a request (all responses must be Release and Public)
- Responses that are deleted should not be factored in for closing as well.
- This also includes the fix to reports (staging security issue).