### PR TITLE
prevent session fixation attacks

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -73,6 +73,7 @@ def ldap_login():
 
             if authenticated:
                 login_user(user)
+                session.regenerate()  # KVSession.regenerate()
                 session['user_id'] = current_user.get_id()
 
                 return_to_url = request.form.get('return_to_url')

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ class Config:
                          os.path.join(os.path.abspath(os.path.dirname(__file__)), 'logs/'))
 
     APP_TIMEZONE = os.environ.get('APP_TIMEZONE') or 'US/Eastern'
-    SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE') or True
+    SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE') == 'True'
 
     # Note: BASE_URL and VIEW_REQUEST_ENDPOINT used for the automatic status update job (jobs.py)
     BASE_URL = os.environ.get('BASE_URL')


### PR DESCRIPTION
PyCharm won't recognize `regenerate` as a method for `session` since it doesn't take into account the KVSessionExtension. As far as PyCharm's concerned, `session` is a `werkzeug.local.LocalProxy` not a `flask_kvsession.KVSession`.